### PR TITLE
Prevent symlink creation erroring out the install script

### DIFF
--- a/arch.sh
+++ b/arch.sh
@@ -22,8 +22,11 @@ if [[ "$*" == *"--profile dev"* ]]; then
     npm install -g npm@6
     # install snap
     pacman -S --noconfirm --needed snapd
-    # symlink workaround for snap
-    ln -s /var/lib/snapd/snap /snap
+    # don't create the symlink if it already exists, as the script will error out
+    if [ ! -L "/snap" ]; then
+        # symlink workaround for snap
+        ln -s /var/lib/snapd/snap /snap
+    fi
     # install pycharm
     snap install pycharm-professional --classic
 fi


### PR DESCRIPTION
Check for existing Snap symlink for deployments on archlike distros. Symlink creation would previously error out the install script and stop the installation process, if the symlink already existed from a previous deployment/installation (can be quite common for development deployments).